### PR TITLE
fix: use the valid exec name :bug: closes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can also build Wallpeek for other operating systems using the provided `Make
 
 ### Dependencies
 
-*   **`wypaper` (Linux only, optional):** For enhanced wallpaper setting on Linux. Install it via your distribution's package manager or from source.
+*   **`waypaper` (Linux only, optional):** For enhanced wallpaper setting on Linux. Install it via your distribution's package manager or from source.
 
 ## 💡 Usage
 

--- a/main.go
+++ b/main.go
@@ -252,8 +252,9 @@ func setWallpaper(path string) {
 	case "darwin":
 		cmd = exec.Command("osascript", "-e", fmt.Sprintf(`tell application "Finder" to set desktop picture to POSIX file "%s"`, path))
 	case "linux":
-		if _, err := exec.LookPath("wypaper"); err == nil {
-			cmd = exec.Command("waypaper", "--Wallpaper", path)
+		const waypaper = "waypaper"
+		if _, err := exec.LookPath(waypaper); err == nil {
+			cmd = exec.Command(waypaper, "--wallpaper", path)
 		} else {
 			cmd = exec.Command("gsettings", "set", "org.gnome.desktop.background", "picture-uri", "file://"+path)
 		}

--- a/main.go
+++ b/main.go
@@ -262,5 +262,8 @@ func setWallpaper(path string) {
 		fmt.Println("Wallpaper change not implemented on", runtime.GOOS)
 		return
 	}
-	_ = cmd.Run()
+
+	if err := cmd.Run(); err != nil {
+		fmt.Println(err)
+	}
 }


### PR DESCRIPTION
This should fix the issue of `waypaper` command..